### PR TITLE
Edit Address for Event #275

### DIFF
--- a/social/views.py
+++ b/social/views.py
@@ -973,6 +973,7 @@ class EventEditView(LoginRequiredMixin, View):
                         event.eventdescription = edit_event.eventdescription
                         event.eventdate = edit_event.eventdate
                         event.eventlocation = edit_event.eventlocation
+                        event.event_address = reverse_location(edit_event.eventlocation)
                         event.eventcapacity = edit_event.eventcapacity
                         event.eventduration = edit_event.eventduration
                         event.save()


### PR DESCRIPTION
The bug has been fixed. When a user changes the location while editing an event, the address field changes, as well.